### PR TITLE
A dependency was using incompatible parameters

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -41,7 +41,7 @@ workflows:
             # debug log
             set -x
 
-            bazel build //app:app
+            bazel build //app:app --incompatible_java_common_parameters=false
     - script@1:
         title: Copy Artifacts
         inputs:
@@ -87,7 +87,7 @@ workflows:
             # debug log
             set -x
 
-            bazel test //app:tests
+            bazel test //app:tests --incompatible_java_common_parameters=false
     - script@1:
         title: Copy Artifacts
         inputs:
@@ -108,3 +108,4 @@ workflows:
 meta:
   bitrise.io:
     stack: linux-docker-android-20.04
+    machine_type_id: elite


### PR DESCRIPTION
Both the primary and deploy workflows were failing with

```
ERROR: /bitrise/src/app/src/main/BUILD:23:19: in kt_jvm_library rule //app/src/main:bazel_kt_kt: 
Traceback (most recent call last):
	File "/root/.cache/bazel/_bazel_root/c9e2538f5e6e6bc4dd528be939659513/external/io_bazel_rules_kotlin/kotlin/internal/jvm/impl.bzl", line 165, column 36, in kt_jvm_library_impl
		_kt_jvm_produce_jar_actions(ctx, "kt_jvm_library") if ctx.attr.srcs else export_only_providers(
	File "/root/.cache/bazel/_bazel_root/c9e2538f5e6e6bc4dd528be939659513/external/io_bazel_rules_kotlin/kotlin/internal/jvm/compile.bzl", line 612, column 42, in kt_jvm_produce_jar_actions
		source_jar = java_common.pack_sources(
Error in pack_sources: in call to pack_sources(), parameter 'output_jar' is deprecated and will be removed soon. It may be temporarily re-enabled by setting --incompatible_java_common_parameters=false
ERROR: /bitrise/src/app/src/main/BUILD:23:19: Analysis of target '//app/src/main:bazel_kt_kt' failed
ERROR: Analysis of target '//app:app' failed; build aborted: 
```